### PR TITLE
Document that Cedar-14 is now deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,13 @@ Xvfb may not be required. If so, consider [this buildpack](https://github.com/he
 
 ## Only supported on Cedar-14
 
-Note that this buildpack only works on Cedar-14 stack. For the Heroku-16 stack only the Headless Chrome buildpack is supported. For more details see [Known Issues for Heroku CI](https://devcenter.heroku.com/articles/heroku-ci#xvfb-chrome-buildpack-and-heroku-16).
+Note that this buildpack only works on the Cedar-14 stack, for which the end-of-life
+window [began May 1, 2019](https://devcenter.heroku.com/changelog-items/1603).
+
+For newer stacks such as Heroku-16 and Heroku-18 you must instead use the more modern
+[Google Chrome Buildpack](https://github.com/heroku/heroku-buildpack-google-chrome),
+which runs Chrome in headless mode without Xvfb. For more details see
+[Browser and User Acceptance Testing](https://devcenter.heroku.com/articles/heroku-ci-browser-and-user-acceptance-testing-uat#google-chrome-via-headless).
 
 ## Channels
 

--- a/bin/compile
+++ b/bin/compile
@@ -33,6 +33,8 @@ function indent() {
 stack=${STACK:-heroku-16}
 if [ "${stack,,}" != "cedar-14" ]; then
   error "The Google Chrome Xvfb buildpack is only supported on Cedar-14."
+  error "For newer stacks you must instead use Google Chrome Buildpack,"
+  error "which runs Chrome in headless mode without Xvfb."
   error "For more details see:"
   error "https://devcenter.heroku.com/articles/heroku-ci#known-issues"
   exit 1


### PR DESCRIPTION
And add more detail to the error message shown when this buildpack runs on incompatible stacks.